### PR TITLE
Improve qemu VM management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,7 @@ agent/hooking/*/bin.X64
 agent/hooking/bin.X86
 
 # images
-*.qcow2
+workers/*.qcow2
+workers/snapshot.gz
 
 data

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ This dataset could then be used in machine learning to try to classify samples b
 - [X] Python3 for the setup script
 
 ### Procedure
-Just run `pip3 install -r requirements.txt` and `python3 setup.py -w <nbr_workers>` to install the project.  
+To install the project, run the following commands:
+```python
+pip3 install -r requirements.txt
+python3 setup.py -w <nbr_workers>
+```
 
-This script will download, decompress and convert a Windows7 VM to a qcow2 image.  
-Then, it will run the VM inside a container and configure the VM then install the agent and its dependencies.  
-It will make a snapshot of the VM and setup the number of workers you want.  
-Do not worry, it's going to take some time to finish...
+You can also use the option `--dev` to configure the project for developement.
 
 ## Running the projet
 To run the project, just use the following command:

--- a/backend/jobs/views.py
+++ b/backend/jobs/views.py
@@ -38,10 +38,10 @@ class JobViewSet(
 
         output = job.results
         extension = output.path.split(".")[-1]
-        filename = output.path.split('/')[-1]
+        filename = output.path.split("/")[-1]
 
         response = FileResponse(output, content_type="application/" + extension)
         response["Content-Length"] = len(output)
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
-        
+
         return response

--- a/backend/workers/tasks.py
+++ b/backend/workers/tasks.py
@@ -8,6 +8,12 @@ from workers.models import Worker
 from jobs.models import JobState
 
 
+NETWORK = "autodetours_autodetours_lan"
+INPUT_DIR = os.environ.get("WIN7_IMAGES_DIR")
+NB_WORKERS = int(os.environ.get("NB_WIN7_WORKERS"))
+QEMU_IMAGE = "autodetours_qemu"
+
+
 @shared_task
 def worker_delete(ip):
     """Celery task used to remove a qemu container. This task
@@ -17,7 +23,9 @@ def worker_delete(ip):
     Args:
         ip (String): IP address of the container associated to the worker.
     """
+
     client = docker.DockerClient(base_url="unix://var/run/docker.sock")
+
     print("Looking up container using ip %s for deletion" % ip)
     for c in client.containers.list():
         for network, infos in c.attrs["NetworkSettings"]["Networks"].items():
@@ -33,6 +41,7 @@ def workers_timeout():
     This mean that the job is taking too much time or simply that something
     crashed.
     """
+
     for worker in Worker.objects.filter(job__state=JobState.RUNNING):
         delta = timezone.now() - worker.job.start_time
         limit = worker.job.job_time * 5
@@ -51,26 +60,31 @@ def workers_automation():
     of worker defined in the installation step.
     Its job is just to create container used to executes jobs.
     """
-    input_dir = os.environ.get("WIN7_IMAGES_DIR")
-    output_dir = "/image/"
-    network = "autodetours_autodetours_lan"
-    nb_workers = int(os.environ.get("NB_WIN7_WORKERS"))
-    workers = {}
-    for i in range(nb_workers):
-        workers["autodetours_workers_%i" % i] = "win7-%i.qcow2" % i
+
     client = docker.DockerClient(base_url="unix://var/run/docker.sock")
 
-    for worker, image in workers.items():
+    cmd = [
+        "-nographic",
+        "-m 1024",
+        "--enable-kvm",
+        "-snapshot",
+        '-incoming "exec: gzip -c -d /image/snapshot.gz"',
+        "-hda /image/win7.qcow2",
+    ]
+    cmd = " ".join(cmd)
+
+    for i in range(NB_WORKERS):
+        worker = f"autodetours_workers_{i}"
         try:
             client.containers.get(worker)
         except docker.errors.NotFound:
-            print("Runnning worker %s" % worker)
+            print(f"Runnning worker {worker}")
             client.containers.run(
-                "autodetours_qemu",
-                command=f"-nographic -m 1024 -loadvm agent -enable-kvm -hda {output_dir}{image}",
-                network=network,
+                QEMU_IMAGE,
+                command=cmd,
+                network=NETWORK,
                 devices=["/dev/kvm"],
-                volumes={input_dir: {"bind": output_dir, "mode": "rw"}},
+                volumes={INPUT_DIR: {"bind": "/image", "mode": "ro"}},
                 remove=True,
                 name=worker,
                 detach=True,


### PR DESCRIPTION
Use external snapshots in qemu to avoid the need of an image per worker. (cf. #39)
